### PR TITLE
Usar a pasta 'data/uploads' para guardar os uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ composer.phar
 vendor/
 .directory
 arquivo
-archives
 .settings
 .metadata
 *.sublime-project

--- a/data/uploads/.gitignore
+++ b/data/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/module/LSInteraction/src/LSInteraction/Controller/InteractionController.php
+++ b/module/LSInteraction/src/LSInteraction/Controller/InteractionController.php
@@ -77,7 +77,7 @@ class InteractionController extends CrudController
                   //Registra o arquivo
                   if ($_FILES['archive']['name'] && $interaction) {
 
-                      $upload = new UploadFile(new Http(), 'archives', $ticket->getId(), $interaction->getId());
+                      $upload = new UploadFile(new Http(), 'data/uploads', $ticket->getId(), $interaction->getId());
 
                       //Registra o Arquivo
                       $service2 = $this->getServiceLocator()->get('LSBase\Service\Archive');

--- a/module/LSTicket/src/LSTicket/Controller/TicketController.php
+++ b/module/LSTicket/src/LSTicket/Controller/TicketController.php
@@ -101,7 +101,7 @@ class TicketController extends CrudController
                 //Registra o arquivo
                 if ($_FILES['archive']['name'] && $interaction) {
 
-                    $upload = new UploadFile(new Http(), 'archives', $ticket->getId(), $interaction->getId());
+                    $upload = new UploadFile(new Http(), 'data/uploads', $ticket->getId(), $interaction->getId());
 
                     //Registra o Arquivo
                     $service3 = $this->getServiceLocator()->get('LSBase\Service\Archive');
@@ -136,7 +136,7 @@ class TicketController extends CrudController
 
         if ($delete) {
 
-            $this->delTree('archives'.DIRECTORY_SEPARATOR.$param);
+            $this->delTree('data/uploads'.DIRECTORY_SEPARATOR.$param);
 
             return $this->redirect()->toRoute($this->route, array('controller' => $this->controller));
         } else {

--- a/public/download.php
+++ b/public/download.php
@@ -5,7 +5,7 @@ set_time_limit(0);
 // Arqui você faz as validações e/ou pega os dados do banco de dados
 
 $aquivoNome = $_GET['archive']; // nome do arquivo que será enviado p/ download
-$arquivoLocal = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'archives'.DIRECTORY_SEPARATOR.$_GET['interaction'].DIRECTORY_SEPARATOR.$_GET['id'].DIRECTORY_SEPARATOR.$aquivoNome; // caminho absoluto do arquivo
+$arquivoLocal = __DIR__ . '/../data/uploads'.DIRECTORY_SEPARATOR.$_GET['interaction'].DIRECTORY_SEPARATOR.$_GET['id'].DIRECTORY_SEPARATOR.$aquivoNome; // caminho absoluto do arquivo
 
 // Verifica se o arquivo não existe
 if (!file_exists($arquivoLocal)) {


### PR DESCRIPTION
Convencionalmente a pasta `data` é utilizada para guardar esses arquivos "de dados".

Eu não usei a constante `DIRECTORY_SEPARATOR` porque ela é completamente desnecessária, o `/` funciona tanto no Windows como nos sistemas *nix. Inclusive seria interessante remover ela do repositório inteiro, oq vcs acham?
